### PR TITLE
command property: replace string concatenation by taking over given list

### DIFF
--- a/autocompose.py
+++ b/autocompose.py
@@ -10,12 +10,14 @@ def main():
     args = parser.parse_args()
 
     struct = {}
-    networks = []
+    networks = set()
     for cname in args.cnames:
-        cfile, networks = generate(cname)
-        struct.update(cfile)
+        cfile, c_networks = generate(cname)
 
-    render(struct, args, networks)
+        struct.update(cfile)
+        networks.update(c_networks)
+
+    render(struct, args, list(networks))
 
 
 def render(struct, args, networks):


### PR DESCRIPTION
Hi,

I noticed that the script is converting the command property. The [specification](https://docs.docker.com/compose/compose-file/compose-file-v3/#command) allows to have
1. a string where arguments are separated by whitespaces
```yaml
command: mycommand arg1 arg2 --flag1 'param'
```
2. a list where all arguments are list items
```yaml
command:
  - mycommand
  - arg1
  - arg2
  - --flag1
  - \'param\'
```

However the Script generated a List with one string item that included all arguments. That resulted in an error.
```yaml
command:
  - mycommand arg1 arg2 --flag1 'param'
```
Thus I removed the usage of `" ".join()` and took over the list which is generated by docker anyway.

Furthermore I came across the issue that the script only collects the networks to which the last container is connected. This has also been fixed.