### PR TITLE
Fix ERROR: network must be a mapping, not an array.

### DIFF
--- a/autocompose.py
+++ b/autocompose.py
@@ -10,14 +10,14 @@ def main():
     args = parser.parse_args()
 
     struct = {}
-    networks = set()
+    networks = {}
     for cname in args.cnames:
         cfile, c_networks = generate(cname)
 
         struct.update(cfile)
         networks.update(c_networks)
 
-    render(struct, args, list(networks))
+    render(struct, args, networks)
 
 
 def render(struct, args, networks):


### PR DESCRIPTION
Hi! First of all thanks for your great work. 

I tried to use this library. However, I had several problems. I will open separate PR for each of them.
This PR is meant to fix the error in the title. Networks was converted to a list before being passes to function render, but it should rather be a mapping.