### PR TITLE
Adding Name Attribute to each Network

### DIFF
--- a/autocompose.py
+++ b/autocompose.py
@@ -93,7 +93,8 @@ def generate(cname):
         networklist = c.networks.list()
         for network in networklist:
             if network.attrs['Name'] in values['networks']:
-                networks[network.attrs['Name']] = {'external': (not network.attrs['Internal'])}
+                networks[network.attrs['Name']] = {'external': (not network.attrs['Internal']),
+                                                   'name': network.attrs['Name']}
 
     # Check for command and add it if present.
     if cattrs['Config']['Cmd'] is not None:

--- a/autocompose.py
+++ b/autocompose.py
@@ -10,14 +10,14 @@ def main():
     args = parser.parse_args()
 
     struct = {}
-    networks = set()
+    networks = {}
     for cname in args.cnames:
         cfile, c_networks = generate(cname)
 
         struct.update(cfile)
         networks.update(c_networks)
 
-    render(struct, args, list(networks))
+    render(struct, args, networks)
 
 
 def render(struct, args, networks):


### PR DESCRIPTION
Hi,

the script currently retrieves the network names as is and writes them into the compose file. 

When using that compose file docker compose is adding the directory name as prefix to the network name. This is no problem if a whole multi-container deployment is replaced by another coming from the generated compose file.

However I´m using this script to replace only a subset of containers by a docker-compose definition and that portion is supposed to communicate to the other containers which were left untouched. So I need the recreated containers in the same networks as the untouched ones. To achieve that, I added the `name:` attribute to each network next to the `external:` which is already there.