### PR TITLE
Fix volumes missing in generated compose file

### DIFF
--- a/autocompose.py
+++ b/autocompose.py
@@ -124,10 +124,9 @@ def generate(cname):
                                                    'name': network.attrs['Name']}
 
     volumes = {}
-    for volume in c.volumes.list():
+    for volume in values['volumes']:
         volume_name = volume.split(':')[0]
-        new_volume = {external: true}
-        volumes[volume_name] = new_volume
+        volumes[volume_name] = {'external': True}
 
     # Check for command and add it if present.
     if cattrs['Config']['Cmd'] is not None:

--- a/autocompose.py
+++ b/autocompose.py
@@ -124,7 +124,7 @@ def generate(cname):
                                                    'name': network.attrs['Name']}
 
     volumes = {}
-    for volume in c.volumes.list()
+    for volume in c.volumes.list():
         volume_name = volume.split(':')[0]
         new_volume = {external: true}
         volumes[volume_name] = new_volume

--- a/autocompose.py
+++ b/autocompose.py
@@ -90,7 +90,8 @@ def generate(cname):
         'networks': {x for x in cattrs['NetworkSettings']['Networks'].keys() if x != 'bridge'},
         'security_opt': cattrs['HostConfig']['SecurityOpt'],
         'ulimits': cattrs['HostConfig']['Ulimits'],
-        'volumes': cattrs['HostConfig']['Binds'],
+        'volumes': cattrs['HostConfig']['Binds'] or
+                   [f'{m["Source"]}:{m["Target"]}' for m in cattrs['HostConfig']['Mounts']],
         'volume_driver': cattrs['HostConfig']['VolumeDriver'],
         'volumes_from': cattrs['HostConfig']['VolumesFrom'],
         'entrypoint': cattrs['Config']['Entrypoint'],

--- a/autocompose.py
+++ b/autocompose.py
@@ -12,7 +12,7 @@ def list_container_names():
 def main():
     parser = argparse.ArgumentParser(description='Generate docker-compose yaml definition from running container.')
     parser.add_argument('-a', '--all', action='store_true', help='Include all active containers')
-    parser.add_argument('-v', '--version', type=int, default=3, help='Compose file version (1 or 3)') 
+    parser.add_argument('-v', '--version', type=int, default=3, help='Compose file version (1 or 3)')
     parser.add_argument('cnames', nargs='*', type=str, help='The name of the container to process.')
     args = parser.parse_args()
 


### PR DESCRIPTION
ref: https://github.com/Red5d/docker-autocompose/issues/17

Tested with my local container that has a volume, before, the container would not create with the exported compose file, now it will. Volumes are assumed to be external, and users will have to create the volume before trying to create the container. Didn't see any way to determine this based off of output of `docker inspect`.

These commits are a little messy, probably want to squash them when merging into a single commit with a message along the lines of what is in the title.

Example output with change:

```
version: "3"
services:
  uptime-kuma:
    cap_add:
      - AUDIT_WRITE
      - CHOWN
      - DAC_OVERRIDE
      - FOWNER
      - FSETID
      - KILL
      - MKNOD
      - NET_BIND_SERVICE
      - NET_RAW
      - SETFCAP
      - SETGID
      - SETPCAP
      - SETUID
      - SYS_CHROOT
    cap_drop:
      - AUDIT_CONTROL
      - BLOCK_SUSPEND
      - DAC_READ_SEARCH
      - IPC_LOCK
      - IPC_OWNER
      - LEASE
      - LINUX_IMMUTABLE
      - MAC_ADMIN
      - MAC_OVERRIDE
      - NET_ADMIN
      - NET_BROADCAST
      - SYSLOG
      - SYS_ADMIN
      - SYS_BOOT
      - SYS_MODULE
      - SYS_NICE
      - SYS_PACCT
      - SYS_PTRACE
      - SYS_RAWIO
      - SYS_RESOURCE
      - SYS_TIME
      - SYS_TTY_CONFIG
      - WAKE_ALARM
    command:
      - node
      - server/server.js
    container_name: uptime-kuma
    entrypoint:
      - /usr/bin/dumb-init
      - --
      - extra/entrypoint.sh
    environment:
      - NODE_VERSION=16.15.0
      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
      - YARN_VERSION=1.22.18
    hostname: 37924a2a5be5
    image: louislam/uptime-kuma:1
    ipc: private
    logging:
      driver: json-file
      options: {}
    ports:
      - 3001:3001/tcp
    restart: always
    volumes:
      - uptime-kuma:/app/data
    working_dir: /app
networks: {}
volumes:
  uptime-kuma:
    external: true
```

Example output before change:
```
version: "3"
services:
  uptime-kuma:
    cap_add:
      - AUDIT_WRITE
      - CHOWN
      - DAC_OVERRIDE
      - FOWNER
      - FSETID
      - KILL
      - MKNOD
      - NET_BIND_SERVICE
      - NET_RAW
      - SETFCAP
      - SETGID
      - SETPCAP
      - SETUID
      - SYS_CHROOT
    cap_drop:
      - AUDIT_CONTROL
      - BLOCK_SUSPEND
      - DAC_READ_SEARCH
      - IPC_LOCK
      - IPC_OWNER
      - LEASE
      - LINUX_IMMUTABLE
      - MAC_ADMIN
      - MAC_OVERRIDE
      - NET_ADMIN
      - NET_BROADCAST
      - SYSLOG
      - SYS_ADMIN
      - SYS_BOOT
      - SYS_MODULE
      - SYS_NICE
      - SYS_PACCT
      - SYS_PTRACE
      - SYS_RAWIO
      - SYS_RESOURCE
      - SYS_TIME
      - SYS_TTY_CONFIG
      - WAKE_ALARM
    command:
      - node
      - server/server.js
    container_name: uptime-kuma
    entrypoint:
      - /usr/bin/dumb-init
      - --
      - extra/entrypoint.sh
    environment:
      - NODE_VERSION=16.15.0
      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
      - YARN_VERSION=1.22.18
    hostname: 37924a2a5be5
    image: louislam/uptime-kuma:1
    ipc: private
    logging:
      driver: json-file
      options: {}
    ports:
      - 3001:3001/tcp
    restart: always
    volumes:
      - uptime-kuma:/app/data
    working_dir: /app
networks: {}
```