### PR TITLE
better handling for default networks

### DIFF
--- a/autocompose.py
+++ b/autocompose.py
@@ -110,7 +110,7 @@ def generate(cname):
         'networks': {x for x in cattrs['NetworkSettings']['Networks'].keys() if x not in default_networks},
         'security_opt': cattrs['HostConfig']['SecurityOpt'],
         'ulimits': cattrs['HostConfig']['Ulimits'],
-        'volumes': cattrs['HostConfig']['Binds'],
+        'volumes': [f'{m["Name"]}:{m["Destination"]}' for m in cattrs['Mounts'] if m['Type'] == 'volume'],
         'volume_driver': cattrs['HostConfig']['VolumeDriver'],
         'volumes_from': cattrs['HostConfig']['VolumesFrom'],
         'entrypoint': cattrs['Config']['Entrypoint'],

--- a/autocompose.py
+++ b/autocompose.py
@@ -145,7 +145,7 @@ def generate(cname):
                                                    'name': network.attrs['Name']}
 
     volumes = {}
-    if values['volumes']:
+    if values['volumes'] is not None:
         for volume in values['volumes']:
             volume_name = volume.split(':')[0]
             volumes[volume_name] = {'external': True}

--- a/autocompose.py
+++ b/autocompose.py
@@ -27,11 +27,16 @@ def main():
         cfile, c_networks, c_volumes = generate(cname)
 
         struct.update(cfile)
+
         if c_networks is None:
             networks = None
         else:
             networks.update(c_networks)
-        volumes.update(c_volumes)
+
+        if c_volumes is None:
+            volumes = None
+        else:
+            volumes.update(c_volumes)
 
     render(struct, args, networks, volumes)
 
@@ -41,10 +46,13 @@ def render(struct, args, networks, volumes):
     if args.version == 1:
         pyaml.p(OrderedDict(struct))
     else:
-        ans = {'version': '"3"', 'services': struct, 'volumes': volumes}
+        ans = {'version': '"3"', 'services': struct}
 
         if networks is not None:
             ans['networks'] = networks
+
+        if volumes is not None:
+            ans['volumes'] = volumes
 
         pyaml.p(OrderedDict(ans))
 
@@ -137,9 +145,12 @@ def generate(cname):
                                                    'name': network.attrs['Name']}
 
     volumes = {}
-    for volume in values['volumes']:
-        volume_name = volume.split(':')[0]
-        volumes[volume_name] = {'external': True}
+    if values['volumes']:
+        for volume in values['volumes']:
+            volume_name = volume.split(':')[0]
+            volumes[volume_name] = {'external': True}
+    else:
+        volumes = None
 
     # Check for command and add it if present.
     if cattrs['Config']['Cmd'] is not None:

--- a/autocompose.py
+++ b/autocompose.py
@@ -27,7 +27,10 @@ def main():
         cfile, c_networks, c_volumes = generate(cname)
 
         struct.update(cfile)
-        networks.update(c_networks)
+        if c_networks is None:
+            networks = None
+        else:
+            networks.update(c_networks)
         volumes.update(c_volumes)
 
     render(struct, args, networks, volumes)
@@ -38,7 +41,12 @@ def render(struct, args, networks, volumes):
     if args.version == 1:
         pyaml.p(OrderedDict(struct))
     else:
-        pyaml.p(OrderedDict({'version': '"3"', 'services': struct, 'networks': networks, 'volumes': volumes}))
+        ans = {'version': '"3"', 'services': struct, 'volumes': volumes}
+
+        if networks is not None:
+            ans['networks'] = networks
+
+        pyaml.p(OrderedDict(ans))
 
 
 def is_date_or_time(s: str):
@@ -73,6 +81,8 @@ def generate(cname):
     cfile[cattrs['Name'][1:]] = {}
     ct = cfile[cattrs['Name'][1:]]
 
+    default_networks = ['bridge', 'host', 'none']
+
     values = {
         'cap_add': cattrs['HostConfig']['CapAdd'],
         'cap_drop': cattrs['HostConfig']['CapDrop'],
@@ -89,7 +99,7 @@ def generate(cname):
         #'log_driver': cattrs['HostConfig']['LogConfig']['Type'],
         #'log_opt': cattrs['HostConfig']['LogConfig']['Config'],
         'logging': {'driver': cattrs['HostConfig']['LogConfig']['Type'], 'options': cattrs['HostConfig']['LogConfig']['Config']},
-        'networks': {x for x in cattrs['NetworkSettings']['Networks'].keys() if x != 'bridge'},
+        'networks': {x for x in cattrs['NetworkSettings']['Networks'].keys() if x not in default_networks},
         'security_opt': cattrs['HostConfig']['SecurityOpt'],
         'ulimits': cattrs['HostConfig']['Ulimits'],
         'volumes': cattrs['HostConfig']['Binds'],
@@ -112,10 +122,13 @@ def generate(cname):
     # Populate devices key if device values are present
     if cattrs['HostConfig']['Devices']:
         values['devices'] = [x['PathOnHost']+':'+x['PathInContainer'] for x in cattrs['HostConfig']['Devices']]
-    
+
     networks = {}
     if values['networks'] == set():
         del values['networks']
+        assumed_default_network = list(cattrs['NetworkSettings']['Networks'].keys())[0]
+        values['network_mode'] = assumed_default_network
+        networks = None
     else:
         networklist = c.networks.list()
         for network in networklist:


### PR DESCRIPTION
Currently, the default networks are either placed in the networks object, or filtered out in the case of "bridge".

docker compose does not support default networks in the "networks" object. Ref: https://github.com/docker/compose/issues/3012

This change updates the code to filter out all default networks, and if there are no networks when the networks object is being created, it grabs the first network from the list of networks, sets "network-mode" on the values, and removes the network object from the generated compose file.

Couple of examples:

Before change:
```
version: "3"
services:
  uptime-kuma:
    cap_add:
      - AUDIT_WRITE
      - CHOWN
      - DAC_OVERRIDE
      - FOWNER
      - FSETID
      - KILL
      - MKNOD
      - NET_BIND_SERVICE
      - NET_RAW
      - SETFCAP
      - SETGID
      - SETPCAP
      - SETUID
      - SYS_CHROOT
    cap_drop:
      - AUDIT_CONTROL
      - BLOCK_SUSPEND
      - DAC_READ_SEARCH
      - IPC_LOCK
      - IPC_OWNER
      - LEASE
      - LINUX_IMMUTABLE
      - MAC_ADMIN
      - MAC_OVERRIDE
      - NET_ADMIN
      - NET_BROADCAST
      - SYSLOG
      - SYS_ADMIN
      - SYS_BOOT
      - SYS_MODULE
      - SYS_NICE
      - SYS_PACCT
      - SYS_PTRACE
      - SYS_RAWIO
      - SYS_RESOURCE
      - SYS_TIME
      - SYS_TTY_CONFIG
      - WAKE_ALARM
    command:
      - node
      - server/server.js
    container_name: uptime-kuma
    entrypoint:
      - /usr/bin/dumb-init
      - --
      - extra/entrypoint.sh
    environment:
      - NODE_VERSION=16.15.0
      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
      - YARN_VERSION=1.22.18
    hostname: 37924a2a5be5
    image: louislam/uptime-kuma:1
    ipc: private
    logging:
      driver: json-file
      options: {}
    ports:
      - 3001:3001/tcp
    restart: always
    volumes:
      - uptime-kuma:/app/data
    working_dir: /app
networks: {}
volumes:
  uptime-kuma:
    external: true
```

After change:
```
version: "3"
services:
  uptime-kuma:
    cap_add:
      - AUDIT_WRITE
      - CHOWN
      - DAC_OVERRIDE
      - FOWNER
      - FSETID
      - KILL
      - MKNOD
      - NET_BIND_SERVICE
      - NET_RAW
      - SETFCAP
      - SETGID
      - SETPCAP
      - SETUID
      - SYS_CHROOT
    cap_drop:
      - AUDIT_CONTROL
      - BLOCK_SUSPEND
      - DAC_READ_SEARCH
      - IPC_LOCK
      - IPC_OWNER
      - LEASE
      - LINUX_IMMUTABLE
      - MAC_ADMIN
      - MAC_OVERRIDE
      - NET_ADMIN
      - NET_BROADCAST
      - SYSLOG
      - SYS_ADMIN
      - SYS_BOOT
      - SYS_MODULE
      - SYS_NICE
      - SYS_PACCT
      - SYS_PTRACE
      - SYS_RAWIO
      - SYS_RESOURCE
      - SYS_TIME
      - SYS_TTY_CONFIG
      - WAKE_ALARM
    command:
      - node
      - server/server.js
    container_name: uptime-kuma
    entrypoint:
      - /usr/bin/dumb-init
      - --
      - extra/entrypoint.sh
    environment:
      - NODE_VERSION=16.15.0
      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
      - YARN_VERSION=1.22.18
    hostname: 37924a2a5be5
    image: louislam/uptime-kuma:1
    ipc: private
    logging:
      driver: json-file
      options: {}
    mac_address: 02:42:ac:11:00:04
    network_mode: bridge
    ports:
      - 3001:3001/tcp
    restart: always
    volumes:
      - uptime-kuma:/app/data
    working_dir: /app
volumes:
  uptime-kuma:
    external: true
```

Before change:
```
version: "3"
services:
  guacamole:
    cap_add:
      - AUDIT_WRITE
      - CHOWN
      - DAC_OVERRIDE
      - FOWNER
      - FSETID
      - KILL
      - MKNOD
      - NET_BIND_SERVICE
      - NET_RAW
      - SETFCAP
      - SETGID
      - SETPCAP
      - SETUID
      - SYS_CHROOT
    cap_drop:
      - AUDIT_CONTROL
      - BLOCK_SUSPEND
      - DAC_READ_SEARCH
      - IPC_LOCK
      - IPC_OWNER
      - LEASE
      - LINUX_IMMUTABLE
      - MAC_ADMIN
      - MAC_OVERRIDE
      - NET_ADMIN
      - NET_BROADCAST
      - SYSLOG
      - SYS_ADMIN
      - SYS_BOOT
      - SYS_MODULE
      - SYS_NICE
      - SYS_PACCT
      - SYS_PTRACE
      - SYS_RAWIO
      - SYS_RESOURCE
      - SYS_TIME
      - SYS_TTY_CONFIG
      - WAKE_ALARM
    container_name: guacamole
    entrypoint:
      - /init
    environment:
      - PATH=/usr/lib/postgresql/11/bin:/usr/local/tomcat/bin:/usr/local/openjdk-15/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
      - JAVA_HOME=/usr/local/openjdk-15
      - LANG=C.UTF-8
      - JAVA_VERSION=15.0.2
      - CATALINA_HOME=/usr/local/tomcat
      - TOMCAT_NATIVE_LIBDIR=/usr/local/tomcat/native-jni-lib
      - LD_LIBRARY_PATH=/usr/local/tomcat/native-jni-lib
      - TOMCAT_MAJOR=9
      - TOMCAT_VERSION=9.0.43
      - APPLICATION=guacamole
      - BUILD_RFC3339=2021-02-15T11:14:14Z
      - REVISION=b467f1a
      - 'DESCRIPTION=A Docker Container for Apache Guacamole, a client-less remote
        desktop gateway. It supports standard protocols like VNC, RDP, and SSH over
        HTML5. For x64 and arm64.'
      - PACKAGE=maxwaldorf/guacamole
      - VERSION=v1.3.1-2-gb467f1a
      - ARCH=amd64
      - GUAC_VER=1.3.0
      - GUACAMOLE_HOME=/config/guacamole
      - PG_MAJOR=11
      - PGDATA=/config/postgres
    hostname: 588cc8c86233
    image: maxwaldorf/guacamole:latest
    ipc: private
    labels:
      org.opencontainers.image.authors: MaxWaldorf,OZNU
      org.opencontainers.image.created: '2021-02-15T11:14:14Z'
      org.opencontainers.image.description: 'A Docker Container for Apache Guacamole,
        a client-less remote desktop gateway. It supports standard protocols like
        VNC, RDP, and SSH over HTML5. For x64 and arm64.'
      org.opencontainers.image.documentation: https://github.com/maxwaldorf/guacamole/README.md
      org.opencontainers.image.licenses: GPLv3
      org.opencontainers.image.ref.name: maxwaldorf/guacamole
      org.opencontainers.image.revision: b467f1a
      org.opencontainers.image.source: https://github.com/maxwaldorf/guacamole
      org.opencontainers.image.title: guacamole
      org.opencontainers.image.url: https://hub.docker.com/r/maxwaldorf/guacamole/
      org.opencontainers.image.version: v1.3.1-2-gb467f1a
    logging:
      driver: json-file
      options: {}
    networks:
      - host
    ports:
      - 8080:8080/tcp
    restart: always
    volumes:
      - guacamole:/config
    working_dir: /config
networks:
  host:
    external: true
    name: host
volumes:
  guacamole:
    external: true
```

After change:
```
version: "3"
services:
  guacamole:
    cap_add:
      - AUDIT_WRITE
      - CHOWN
      - DAC_OVERRIDE
      - FOWNER
      - FSETID
      - KILL
      - MKNOD
      - NET_BIND_SERVICE
      - NET_RAW
      - SETFCAP
      - SETGID
      - SETPCAP
      - SETUID
      - SYS_CHROOT
    cap_drop:
      - AUDIT_CONTROL
      - BLOCK_SUSPEND
      - DAC_READ_SEARCH
      - IPC_LOCK
      - IPC_OWNER
      - LEASE
      - LINUX_IMMUTABLE
      - MAC_ADMIN
      - MAC_OVERRIDE
      - NET_ADMIN
      - NET_BROADCAST
      - SYSLOG
      - SYS_ADMIN
      - SYS_BOOT
      - SYS_MODULE
      - SYS_NICE
      - SYS_PACCT
      - SYS_PTRACE
      - SYS_RAWIO
      - SYS_RESOURCE
      - SYS_TIME
      - SYS_TTY_CONFIG
      - WAKE_ALARM
    container_name: guacamole
    entrypoint:
      - /init
    environment:
      - PATH=/usr/lib/postgresql/11/bin:/usr/local/tomcat/bin:/usr/local/openjdk-15/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
      - JAVA_HOME=/usr/local/openjdk-15
      - LANG=C.UTF-8
      - JAVA_VERSION=15.0.2
      - CATALINA_HOME=/usr/local/tomcat
      - TOMCAT_NATIVE_LIBDIR=/usr/local/tomcat/native-jni-lib
      - LD_LIBRARY_PATH=/usr/local/tomcat/native-jni-lib
      - TOMCAT_MAJOR=9
      - TOMCAT_VERSION=9.0.43
      - APPLICATION=guacamole
      - BUILD_RFC3339=2021-02-15T11:14:14Z
      - REVISION=b467f1a
      - 'DESCRIPTION=A Docker Container for Apache Guacamole, a client-less remote
        desktop gateway. It supports standard protocols like VNC, RDP, and SSH over
        HTML5. For x64 and arm64.'
      - PACKAGE=maxwaldorf/guacamole
      - VERSION=v1.3.1-2-gb467f1a
      - ARCH=amd64
      - GUAC_VER=1.3.0
      - GUACAMOLE_HOME=/config/guacamole
      - PG_MAJOR=11
      - PGDATA=/config/postgres
    hostname: 588cc8c86233
    image: maxwaldorf/guacamole:latest
    ipc: private
    labels:
      org.opencontainers.image.authors: MaxWaldorf,OZNU
      org.opencontainers.image.created: '2021-02-15T11:14:14Z'
      org.opencontainers.image.description: 'A Docker Container for Apache Guacamole,
        a client-less remote desktop gateway. It supports standard protocols like
        VNC, RDP, and SSH over HTML5. For x64 and arm64.'
      org.opencontainers.image.documentation: https://github.com/maxwaldorf/guacamole/README.md
      org.opencontainers.image.licenses: GPLv3
      org.opencontainers.image.ref.name: maxwaldorf/guacamole
      org.opencontainers.image.revision: b467f1a
      org.opencontainers.image.source: https://github.com/maxwaldorf/guacamole
      org.opencontainers.image.title: guacamole
      org.opencontainers.image.url: https://hub.docker.com/r/maxwaldorf/guacamole/
      org.opencontainers.image.version: v1.3.1-2-gb467f1a
    logging:
      driver: json-file
      options: {}
    network_mode: host
    ports:
      - 8080:8080/tcp
    restart: always
    volumes:
      - guacamole:/config
    working_dir: /config
volumes:
  guacamole:
    external: true
```