### PR TITLE
Quote all string values to reduce probability of compose syntax errors

### DIFF
--- a/autocompose.py
+++ b/autocompose.py
@@ -117,7 +117,7 @@ def render(struct, args, networks, volumes):
     if args.version == 1:
         pyaml.p(OrderedDict(struct))
     else:
-        ans = {"version": '"3.6"', "services": struct}
+        ans = {"version": '3.6', "services": struct}
 
         if networks is not None:
             ans["networks"] = networks
@@ -126,20 +126,6 @@ def render(struct, args, networks, volumes):
             ans["volumes"] = volumes
 
         pyaml.p(OrderedDict(ans), string_val_style='"')
-
-
-def is_date_or_time(s: str):
-    for parse_func in [datetime.date.fromisoformat, datetime.datetime.fromisoformat]:
-        try:
-            parse_func(s.rstrip("Z"))
-            return True
-        except ValueError:
-            pass
-    return False
-
-
-def fix_label(label: str):
-    return f"'{label}'" if is_date_or_time(label) else label
 
 
 def generate(cname, createvolumes=False):
@@ -171,7 +157,7 @@ def generate(cname, createvolumes=False):
         "environment": cattrs.get("Config", {}).get("Env", None),
         "extra_hosts": cattrs.get("HostConfig", {}).get("ExtraHosts", None),
         "image": cattrs.get("Config", {}).get("Image", None),
-        "labels": {label: fix_label(value) for label, value in cattrs.get("Config", {}).get("Labels", {}).items()},
+        "labels": cattrs.get("Config", {}).get("Labels", {}),
         "links": cattrs.get("HostConfig", {}).get("Links"),
         #'log_driver': cattrs.get('HostConfig']['LogConfig']['Type'],
         #'log_opt': cattrs.get('HostConfig']['LogConfig']['Config'],

--- a/autocompose.py
+++ b/autocompose.py
@@ -125,7 +125,7 @@ def render(struct, args, networks, volumes):
         if volumes is not None:
             ans["volumes"] = volumes
 
-        pyaml.p(OrderedDict(ans))
+        pyaml.p(OrderedDict(ans), string_val_style='"')
 
 
 def is_date_or_time(s: str):


### PR DESCRIPTION
Hello there,
thank you for your work with docker-autocompose!

I encountered some problems when recreating containers when using custom log configs.

In our case we set the log-options as follows:
```
  log_driver: json-file
  log_options:
    max-size: 10m
    max-file: "3"
    tag: "{{.ImageName}}|{{.Name}}|{{.ImageFullID}}|{{.FullID}}"
```

The current master of the script would remove the quotes around tag and max-file, which would make docker-compose interpret these options as malformed dict and integer, both syntax violations.

The proposed solution would quote all values that are strings.

I'm glad to improve my contribution if you have any comments.