### PR TITLE
Fixed crash when network config is None

### DIFF
--- a/src/autocompose.py
+++ b/src/autocompose.py
@@ -51,7 +51,7 @@ def generate_network_info():
                 "driver": network_attributes.get("IPAM", {}).get("Driver", "default"),
                 "config": [
                     {key.lower(): value for key, value in config.items()}
-                    for config in network_attributes.get("IPAM", {}).get("Config", [])
+                    for config in network_attributes.get("IPAM", {}).get("Config", []) or []
                 ],
             },
         }


### PR DESCRIPTION
Found the problem shown in issue #80 

`<dict>.get()` returns the default only when the key does not exist, but when it exists with None value, that value is returned.