### PR TITLE
Added plain string formatting (--plain)

### DIFF
--- a/src/autocompose.py
+++ b/src/autocompose.py
@@ -51,7 +51,7 @@ def generate_network_info():
                 "driver": network_attributes.get("IPAM", {}).get("Driver", "default"),
                 "config": [
                     {key.lower(): value for key, value in config.items()}
-                    for config in network_attributes.get("IPAM", {}).get("Config", [])
+                    for config in network_attributes.get("IPAM", {}).get("Config", []) or []
                 ],
             },
         }

--- a/src/autocompose.py
+++ b/src/autocompose.py
@@ -96,6 +96,12 @@ def main():
         type=str,
         help="Filter containers by regex",
     )
+    parser.add_argument(
+        "-p",
+        "--plain",
+        action="store_true",
+        help="Use plain (non-quoted) strings where possible",
+    )
     args = parser.parse_args()
 
     container_names = args.cnames
@@ -148,7 +154,12 @@ def render(struct, args, networks, volumes):
         if volumes is not None:
             ans["volumes"] = volumes
 
-        pyaml.p(OrderedDict(ans), string_val_style='"')
+        dump_kwargs = {}
+
+        if not args.plain:
+            dump_kwargs["string_val_style"] = '"'
+
+        pyaml.p(OrderedDict(ans), **dump_kwargs)
 
 
 def generate(cname, createvolumes=False):


### PR DESCRIPTION
Added flag to output strings in more human-readable format, without the quotes, except where it is needed to preserve the datatype.

```
-p, --plain           Use plain (non-quoted) strings where possible
```